### PR TITLE
[FEATURE]: add validation for alphanumeric CNPJ

### DIFF
--- a/src/main/kotlin/br/com/docbr/pojo/CNPJ.kt
+++ b/src/main/kotlin/br/com/docbr/pojo/CNPJ.kt
@@ -1,0 +1,13 @@
+package br.com.docbr.pojo
+
+import br.com.docbr.validation.CnpjInspector
+
+class CNPJ(value: String) {
+    val document: String = value
+        .filter { it.isLetterOrDigit() }
+        .uppercase()
+}
+
+fun CNPJ.isValid(): Boolean =
+    CnpjInspector.isCNPJValid(this)
+

--- a/src/main/kotlin/br/com/docbr/validation/CnpjInspector.kt
+++ b/src/main/kotlin/br/com/docbr/validation/CnpjInspector.kt
@@ -1,0 +1,83 @@
+package br.com.docbr.validation
+
+import br.com.docbr.pojo.CNPJ
+
+object CnpjInspector {
+
+    val documentPattern: Regex = Regex("([0-9A-Z]{12})([0-9]{2})")
+
+    fun isCNPJValid(value: CNPJ): Boolean {
+        return isEntryValid(value.document) && isCheckDigitValid(value.document)
+    }
+
+    fun isCNPJValid(value: String): Boolean {
+        val document = CNPJ(value).document
+        return isEntryValid(document) && isCheckDigitValid(document)
+    }
+
+    /**
+     * This method performs validation using a regular expression, ensuring that the
+     * CNPJ follows the expected format:
+     *
+     *   SS.SSS.SSS/SSSS-NN
+     *
+     *   S - Letter or Number
+     *
+     *   N - Number
+     */
+    fun isEntryValid(document: String): Boolean {
+        val patternMatches = documentPattern.matches(document)
+        if (!patternMatches) { throw Exception("Invalid CNPJ") }
+        return true
+    }
+
+    /**
+     * Validates the check digits of the given CNPJ, ensuring that the document
+     * number conforms to the official calculation rules.
+     */
+    fun isCheckDigitValid(document: String): Boolean {
+        val dv = document.substring(document.length - 2 .. document.length - 1)
+        val baseDoc = document.substring(0 .. document.length - 3)
+        if (dv != calcCheckDigit(baseDoc)) throw Exception("Invalid Verifier Digit")
+        return true
+    }
+
+    /**
+     * Calculates the CNPJ alphanumeric check digits (DV)
+     * according to the official calculation rules.
+     */
+    private fun calcCheckDigit(document: String): String {
+        val firstDigit = calcSingleDigit(document)
+        val secondDigit = calcSingleDigit(document.plus(firstDigit))
+        return "$firstDigit$secondDigit"
+    }
+
+    /**
+     * Calculation rules for the CNPJ Alphanumeric check digits (DV):
+     *
+     * 1. Each character (number or letter) is converted into its decimal ASCII value, minus 48
+     *
+     * 2. Apply weight factors from 2 to 9, moving right-to-left, repeating the cycle as needed.
+     *    Example sequence (for 12 characters): 2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5.
+     *
+     * 3. Multiply each character value by its corresponding weight and sum the results.
+     *
+     * 4. Calculate the remainder (sum % 11):
+     *    - If the remainder is 0 or 1, the check digit (DV) = 0.
+     *    - Otherwise, DV = 11 - remainder.
+     */
+    private fun calcSingleDigit(document: String): Int {
+        val result = document.reversed().foldIndexed(0 to 2) { _, (acc, weight), char ->
+            val digit = char.code - 48
+            val newAcc = acc + (digit * weight)
+            val nextWeight = if (weight == 9) 2 else weight + 1
+            newAcc to nextWeight
+        }.first
+
+        return when (result % 11) {
+            0, 1 -> 0
+            else -> 11 - (result % 11)
+        }
+    }
+
+}

--- a/src/test/kotlin/br/com/docbr/validation/CnpjInspectorTest.kt
+++ b/src/test/kotlin/br/com/docbr/validation/CnpjInspectorTest.kt
@@ -1,0 +1,58 @@
+package br.com.docbr.validation
+
+import br.com.docbr.pojo.CNPJ
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CnpjInspectorTest {
+
+    @Test
+    fun `validation should throw exception due to invalid format`() {
+        val invalidCheckDigit = CNPJ("I8.55J.32K/AB09-A5").document
+        val invalidBaseSize = CNPJ("I8.55J.32K/AB0-65").document
+        val invalidCheckDigitSize = CNPJ("I8.55J.32K/AB09-5").document
+
+        assertThrows<Exception> { CnpjInspector.isEntryValid(invalidCheckDigit) }
+        assertThrows<Exception> { CnpjInspector.isEntryValid(invalidBaseSize) }
+        assertThrows<Exception> { CnpjInspector.isEntryValid(invalidCheckDigitSize) }
+    }
+
+    @Test
+    fun `document format should be valid`() {
+        val validDocumentFormat = CNPJ("I8.55J.32K/AB09-65").document
+        assertTrue { CnpjInspector.isEntryValid(validDocumentFormat) }
+    }
+
+    @Test
+    fun `verifier digit should be valid`() {
+        val validDocumentVD = CNPJ("12.ABC.345/01DE-35").document
+        assertTrue { CnpjInspector.isCheckDigitValid(validDocumentVD) }
+    }
+
+    @Test
+    fun `verifier digit should be invalid`() {
+        val invalidDocumentVD = CNPJ("12.ABC.345/01DE-58").document
+        assertThrows<Exception> { CnpjInspector.isCheckDigitValid(invalidDocumentVD) }
+    }
+
+    @Test
+    fun `CNPJ should be valid`() {
+        val validDocumentVD = "12.ABC.345/01DE-35"
+        assertTrue { CnpjInspector.isCNPJValid(validDocumentVD) }
+    }
+
+    @Test
+    fun `CNPJ should be invalid`() {
+        val invalidCheckDigit = "I8.55J.32K/AB09-A5"
+        val invalidBaseSize = "I8.55J.32K/AB0-65"
+        val invalidCheckDigitSize = "I8.55J.32K/AB09-5"
+        val invalidDocumentVD = "12.ABC.345/01DE-58"
+
+        assertThrows<Exception> { CnpjInspector.isCNPJValid(invalidCheckDigit) }
+        assertThrows<Exception> { CnpjInspector.isCNPJValid(invalidBaseSize) }
+        assertThrows<Exception> { CnpjInspector.isCNPJValid(invalidCheckDigitSize) }
+        assertThrows<Exception> { CnpjInspector.isCNPJValid(invalidDocumentVD) }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces support for validating alphanumeric CNPJs, following the official calculation rules defined by Receita Federal (effective from July 2026).

Changes:

- Added validation logic for alphanumeric CNPJ (12 alphanumeric characters + 2 numeric check digits).

- Implemented check digit calculation using the mod 11 algorithm with ASCII–48 conversion for characters.

- Updated regex validation to allow [A-Z0-9]{12}[0-9]{2}.

- Added utility class/methods for CNPJ validation.

- Unit tests covering valid and invalid scenarios.

Notes:

 - This change ensures forward compatibility with the new CNPJ standard.

 - Current numeric-only CNPJs remain fully supported.