### PR TITLE
[BUILD]: add Java 8 compatibility for the library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
 plugins {
 	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.5.5"
-	id("io.spring.dependency-management") version "1.1.7"
 }
 
 group = "br.com"
@@ -20,9 +17,7 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ description = "DocBr"
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(8)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces retrocompatibility with Java 8, ensuring the library can be used in legacy environments.

Changes:

- Updated build configuration to support Java 8.
- Verified that all features remain functional under Java 8 constraints.

Notes:

This update allows broader adoption of the library in projects still running on older Java versions, without impacting Java 11+ users.
